### PR TITLE
bpm_acq: only instantiate pico_range PVs if necessary.

### DIFF
--- a/scripts/python/bpm/bpm.py
+++ b/scripts/python/bpm/bpm.py
@@ -144,7 +144,7 @@ bpmEnums = BPMEnums
 class BPM:
     """BPM Acquistiion class"""
 
-    def __init__(self, prefix, wait_for_connection=False, connection_timeout=5):
+    def __init__(self, prefix, wait_for_connection=False, connection_timeout=5, fmc_pico=False):
         self._prefix = prefix
 
         # Options for epics PV
@@ -192,11 +192,13 @@ class BPM:
             'TbtDataMaskSamplesEnd': 'TbtDataMaskSamplesEnd-SP',
             'XYPosCal': 'XYPosCal-Sel',
             'SUMPosCal': 'SUMPosCal-Sel',
-            'FMCPICORngR0' : 'FMCPICORngR0-Sel',
-            'FMCPICORngR1' : 'FMCPICORngR1-Sel',
-            'FMCPICORngR2' : 'FMCPICORngR2-Sel',
-            'FMCPICORngR3' : 'FMCPICORngR3-Sel'
         }
+        if fmc_pico:
+            pvs['FMCPICORngR0'] = 'FMCPICORngR0-Sel'
+            pvs['FMCPICORngR1'] = 'FMCPICORngR1-Sel'
+            pvs['FMCPICORngR2'] = 'FMCPICORngR2-Sel'
+            pvs['FMCPICORngR3'] = 'FMCPICORngR3-Sel'
+
         self._config_pvs_sp = {
             k: PV(self._prefix + v, **opt) for k, v in pvs.items()
         }
@@ -238,11 +240,13 @@ class BPM:
             'TbtDataMaskSamplesEnd': 'TbtDataMaskSamplesEnd-RB',
             'XYPosCal': 'XYPosCal-Sts',
             'SUMPosCal': 'SUMPosCal-Sts',
-            'FMCPICORngR0' : 'FMCPICORngR0-Sts',
-            'FMCPICORngR1' : 'FMCPICORngR1-Sts',
-            'FMCPICORngR2' : 'FMCPICORngR2-Sts',
-            'FMCPICORngR3' : 'FMCPICORngR3-Sts'
         }
+        if fmc_pico:
+            pvs['FMCPICORngR0'] = 'FMCPICORngR0-Sts'
+            pvs['FMCPICORngR1'] = 'FMCPICORngR1-Sts'
+            pvs['FMCPICORngR2'] = 'FMCPICORngR2-Sts'
+            pvs['FMCPICORngR3'] = 'FMCPICORngR3-Sts'
+
         self._config_pvs_rb = {
             k: PV(self._prefix + v, **opt) for k, v in pvs.items()
         }

--- a/scripts/python/bpm_acq.py
+++ b/scripts/python/bpm_acq.py
@@ -25,8 +25,10 @@ parser.add_argument('--fmcpico_conv', action='store_true', help='FMC PICO conver
 
 args = parser.parse_args()
 
+use_fmc_pico = args.fmcpico_range is not None or args.fmcpico_conv
+
 # Setup acquistiion parameters
-bpm = BPM(args.prefix, wait_for_connection=True)
+bpm = BPM(args.prefix, wait_for_connection=True, fmc_pico=use_fmc_pico)
 
 bpm.nr_samples_pre = args.nr_samples
 bpm.nr_samples_post = args.nr_post_samples


### PR DESCRIPTION
Acquisitions with bpm_acq.py were taking a long time when waiting for a connection (found via the cProfile module [1]), due to non-existing PVs. They are only enabled for XBPMs, so now we only try to connect to them in case they are used.

[1] https://docs.python.org/3/library/profile.html