### PR TITLE
BPMApp: rename Monit1 to FAcq.

### DIFF
--- a/BPMApp/Db/BPMAcq.template
+++ b/BPMApp/Db/BPMAcq.template
@@ -103,7 +103,7 @@ record(mbbo, "$(P)$(R)$(ACQ_NAME)Channel-Sel"){
     field(THST,"fofb")
     field(FRST,"tbtpha")
     field(FVST,"fofbpha")
-    field(SXST,"monit1")
+    field(SXST,"facq")
 }
 
 record(mbbi, "$(P)$(R)$(ACQ_NAME)Channel-Sts"){
@@ -125,7 +125,7 @@ record(mbbi, "$(P)$(R)$(ACQ_NAME)Channel-Sts"){
     field(THST,"fofb")
     field(FRST,"tbtpha")
     field(FVST,"fofbpha")
-    field(SXST,"monit1")
+    field(SXST,"facq")
 }
 
 # For use with rate seq record defined in FFTRecords.template
@@ -342,7 +342,7 @@ record(mbbo,"$(P)$(R)$(ACQ_NAME)DataTrigChan-Sel"){
     field(THST,"fofb")
     field(FRST,"tbtpha")
     field(FVST,"fofbpha")
-    field(SXST,"monit1")
+    field(SXST,"facq")
     field(OUT,"@asynMask($(PORT),$(ADDR),0xFFFFFFFF,$(TIMEOUT))ACQ_DATA_TRIG_CHAN")
 }
 
@@ -364,7 +364,7 @@ record(mbbi,"$(P)$(R)$(ACQ_NAME)DataTrigChan-Sts"){
     field(THST,"fofb")
     field(FRST,"tbtpha")
     field(FVST,"fofbpha")
-    field(SXST,"monit1")
+    field(SXST,"facq")
     field(INP,"@asynMask($(PORT),$(ADDR),0xFFFFFFFF,$(TIMEOUT))ACQ_DATA_TRIG_CHAN")
 }
 

--- a/BPMApp/Db/BPMDsp.template
+++ b/BPMApp/Db/BPMDsp.template
@@ -733,9 +733,9 @@ record(longin,"$(P)$(R)TbTTagDesyncCnt-Mon"){
     field(INP,"@asynMask($(PORT),$(ADDR),0xFFFFFFFF,$(TIMEOUT))DSP_TBT_TAG_DESYNC_CNT")
 }
 
-record(mbbo,"$(P)$(R)Monit1TagEn-Sel"){
+record(mbbo,"$(P)$(R)FAcqTagEn-Sel"){
     field(DTYP,"asynUInt32Digital")
-    field(DESC,"Set Monit1 Tag Enable")
+    field(DESC,"Set FAcq Tag Enable")
     field(PINI,"YES")
     field(SCAN,"Passive")
     field(OUT,"@asynMask($(PORT),$(ADDR),0xFFFFFFFF,$(TIMEOUT))DSP_MONIT1_TAG_EN")
@@ -746,9 +746,9 @@ record(mbbo,"$(P)$(R)Monit1TagEn-Sel"){
     field(ONST,"enabled")
 }
 
-record(mbbi,"$(P)$(R)Monit1TagEn-Sts"){
+record(mbbi,"$(P)$(R)FAcqTagEn-Sts"){
     field(DTYP,"asynUInt32Digital")
-    field(DESC,"Get Monit1 Tag Enable")
+    field(DESC,"Get FAcq Tag Enable")
     field(SCAN,"I/O Intr")
     field(INP,"@asynMask($(PORT),$(ADDR),0xFFFFFFFF,$(TIMEOUT))DSP_MONIT1_TAG_EN")
     field(NOBT,"1")
@@ -758,24 +758,24 @@ record(mbbi,"$(P)$(R)Monit1TagEn-Sts"){
     field(ONST,"enabled")
 }
 
-record(longout,"$(P)$(R)Monit1TagDly-SP"){
+record(longout,"$(P)$(R)FAcqTagDly-SP"){
     field(DTYP,"asynUInt32Digital")
-    field(DESC,"Set Monit1 Tag Delay")
+    field(DESC,"Set FAcq Tag Delay")
     field(PINI,"YES")
     field(SCAN,"Passive")
     field(OUT,"@asynMask($(PORT),$(ADDR),0xFFFFFFFF,$(TIMEOUT))DSP_MONIT1_TAG_DLY")
 }
 
-record(longin,"$(P)$(R)Monit1TagDly-RB"){
+record(longin,"$(P)$(R)FAcqTagDly-RB"){
     field(DTYP,"asynUInt32Digital")
-    field(DESC,"Get Monit1 Tag Delay")
+    field(DESC,"Get FAcq Tag Delay")
     field(SCAN,"I/O Intr")
     field(INP,"@asynMask($(PORT),$(ADDR),0xFFFFFFFF,$(TIMEOUT))DSP_MONIT1_TAG_DLY")
 }
 
-record(mbbo,"$(P)$(R)Monit1DataMaskEn-Sel"){
+record(mbbo,"$(P)$(R)FAcqDataMaskEn-Sel"){
     field(DTYP,"asynUInt32Digital")
-    field(DESC,"Set MONIT1 Data Mask Enable")
+    field(DESC,"Set FAcq Data Mask Enable")
     field(PINI,"YES")
     field(SCAN,"Passive")
     field(OUT,"@asynMask($(PORT),$(ADDR),0xFFFFFFFF,$(TIMEOUT))DSP_MONIT1_DATA_MASK_EN")
@@ -786,9 +786,9 @@ record(mbbo,"$(P)$(R)Monit1DataMaskEn-Sel"){
     field(ONST,"enabled")
 }
 
-record(mbbi,"$(P)$(R)Monit1DataMaskEn-Sts"){
+record(mbbi,"$(P)$(R)FAcqDataMaskEn-Sts"){
     field(DTYP,"asynUInt32Digital")
-    field(DESC,"Get MONIT1 Data Mask Enable")
+    field(DESC,"Get FAcq Data Mask Enable")
     field(SCAN,"I/O Intr")
     field(INP,"@asynMask($(PORT),$(ADDR),0xFFFFFFFF,$(TIMEOUT))DSP_MONIT1_DATA_MASK_EN")
     field(NOBT,"1")
@@ -798,7 +798,7 @@ record(mbbi,"$(P)$(R)Monit1DataMaskEn-Sts"){
     field(ONST,"enabled")
 }
 
-record(longout,"$(P)$(R)Monit1DataMaskSamplesBeg-SP"){
+record(longout,"$(P)$(R)FAcqDataMaskSamplesBeg-SP"){
     field(DTYP,"asynUInt32Digital")
     field(DESC,"Set Data Mask Samples Beg.")
     field(PINI,"YES")
@@ -806,14 +806,14 @@ record(longout,"$(P)$(R)Monit1DataMaskSamplesBeg-SP"){
     field(OUT,"@asynMask($(PORT),$(ADDR),0xFFFFFFFF,$(TIMEOUT))DSP_MONIT1_DATA_MASK_SAMPLES_BEG")
 }
 
-record(longin,"$(P)$(R)Monit1DataMaskSamplesBeg-RB"){
+record(longin,"$(P)$(R)FAcqDataMaskSamplesBeg-RB"){
     field(DTYP,"asynUInt32Digital")
     field(DESC,"Get Data Mask Samples Beg.")
     field(SCAN,"I/O Intr")
     field(INP,"@asynMask($(PORT),$(ADDR),0xFFFFFFFF,$(TIMEOUT))DSP_MONIT1_DATA_MASK_SAMPLES_BEG")
 }
 
-record(longout,"$(P)$(R)Monit1DataMaskSamplesEnd-SP"){
+record(longout,"$(P)$(R)FAcqDataMaskSamplesEnd-SP"){
     field(DTYP,"asynUInt32Digital")
     field(DESC,"Set Data Mask Samples End.")
     field(PINI,"YES")
@@ -821,16 +821,16 @@ record(longout,"$(P)$(R)Monit1DataMaskSamplesEnd-SP"){
     field(OUT,"@asynMask($(PORT),$(ADDR),0xFFFFFFFF,$(TIMEOUT))DSP_MONIT1_DATA_MASK_SAMPLES_END")
 }
 
-record(longin,"$(P)$(R)Monit1DataMaskSamplesEnd-RB"){
+record(longin,"$(P)$(R)FAcqDataMaskSamplesEnd-RB"){
     field(DTYP,"asynUInt32Digital")
     field(DESC,"Get Data Mask Samples End.")
     field(SCAN,"I/O Intr")
     field(INP,"@asynMask($(PORT),$(ADDR),0xFFFFFFFF,$(TIMEOUT))DSP_MONIT1_DATA_MASK_SAMPLES_END")
 }
 
-record(mbbo,"$(P)$(R)Monit1TagDesyncCntRst-Sel") {
+record(mbbo,"$(P)$(R)FAcqTagDesyncCntRst-Sel") {
     field(DTYP,"asynUInt32Digital")
-    field(DESC, "Set Monit1 Counter Reset")
+    field(DESC, "Set FAcq Counter Reset")
     field(PINI, "YES")
     field(SCAN, "Passive")
     field(NOBT, "1")
@@ -841,9 +841,9 @@ record(mbbo,"$(P)$(R)Monit1TagDesyncCntRst-Sel") {
     field(OUT,  "@asynMask($(PORT),$(ADDR),0xFFFFFFFF,$(TIMEOUT))DSP_MONIT1_TAG_DESYNC_CNT_RST")
 }
 
-record(mbbi,"$(P)$(R)Monit1TagDesyncCntRst-Sts") {
+record(mbbi,"$(P)$(R)FAcqTagDesyncCntRst-Sts") {
     field(DTYP,"asynUInt32Digital")
-    field(DESC, "Get Monit1 Counter Reset")
+    field(DESC, "Get FAcq Counter Reset")
     field(SCAN, "I/O Intr")
     field(NOBT, "1")
     field(ZRVL, "0")
@@ -853,9 +853,9 @@ record(mbbi,"$(P)$(R)Monit1TagDesyncCntRst-Sts") {
     field(INP, "@asynMask($(PORT),$(ADDR),0xFFFFFFFF,$(TIMEOUT))DSP_MONIT1_TAG_DESYNC_CNT_RST")
 }
 
-record(longin,"$(P)$(R)Monit1TagDesyncCnt-Mon"){
+record(longin,"$(P)$(R)FAcqTagDesyncCnt-Mon"){
     field(DTYP,"asynUInt32Digital")
-    field(DESC,"Get Monit1 Desync Counter")
+    field(DESC,"Get FAcq Desync Counter")
     field(SCAN,"2 second")
     field(INP,"@asynMask($(PORT),$(ADDR),0xFFFFFFFF,$(TIMEOUT))DSP_MONIT1_TAG_DESYNC_CNT")
 }

--- a/BPMApp/Db/BPMDsp_settings.req
+++ b/BPMApp/Db/BPMDsp_settings.req
@@ -22,11 +22,11 @@ $(P)$(R)TbTTagDly-SP
 $(P)$(R)TbTDataMaskEn-Sel
 $(P)$(R)TbTDataMaskSamplesBeg-SP
 $(P)$(R)TbTDataMaskSamplesEnd-SP
-$(P)$(R)Monit1TagEn-Sel
-$(P)$(R)Monit1TagDly-SP
-$(P)$(R)Monit1DataMaskEn-Sel
-$(P)$(R)Monit1DataMaskSamplesBeg-SP
-$(P)$(R)Monit1DataMaskSamplesEnd-SP
+$(P)$(R)FAcqTagEn-Sel
+$(P)$(R)FAcqTagDly-SP
+$(P)$(R)FAcqDataMaskEn-Sel
+$(P)$(R)FAcqDataMaskSamplesBeg-SP
+$(P)$(R)FAcqDataMaskSamplesEnd-SP
 $(P)$(R)MonitTagEn-Sel
 $(P)$(R)MonitTagDly-SP
 $(P)$(R)MonitDataMaskEn-Sel

--- a/BPMApp/Db/BPMFFT.template
+++ b/BPMApp/Db/BPMFFT.template
@@ -35,7 +35,7 @@ record(seq, "$(P)$(R)$(ARRAY_NAME)AllRates-RB"){
     field(DOL4, "$(P)$(R)INFOFOFBRate-RB PP NMS")
     field(DOL5, "$(P)$(R)INFOTbTRate-RB PP NMS")
     field(DOL6, "$(P)$(R)INFOFOFBRate-RB PP NMS")
-    field(DOL7, "$(P)$(R)INFOMONIT1Rate-RB PP NMS")
+    field(DOL7, "$(P)$(R)INFOFAcqRate-RB PP NMS")
     field(LNK1, "$(P)$(R)$(ARRAY_NAME)CurrentRate-RB PP NMS")
     field(LNK2, "$(P)$(R)$(ARRAY_NAME)CurrentRate-RB PP NMS")
     field(LNK3, "$(P)$(R)$(ARRAY_NAME)CurrentRate-RB PP NMS")

--- a/BPMApp/Db/BPMInfo.template
+++ b/BPMApp/Db/BPMInfo.template
@@ -153,17 +153,17 @@ record(longin,"$(P)$(R)INFOMONITRate-RB"){
     field(INP,"@asynMask($(PORT),$(ADDR),0xFFFFFFFF,$(TIMEOUT))INFO_MONITRATE")
 }
 
-record(longout,"$(P)$(R)INFOMONIT1Rate-SP"){
+record(longout,"$(P)$(R)INFOFAcqRate-SP"){
     field(DTYP,"asynUInt32Digital")
-    field(DESC,"set MONIT1 rate factor")
+    field(DESC,"set FAcq rate factor")
     field(PINI,"YES")
     field(SCAN,"Passive")
     field(OUT,"@asynMask($(PORT),$(ADDR),0xFFFFFFFF,$(TIMEOUT))INFO_MONIT1RATE")
 }
 
-record(longin,"$(P)$(R)INFOMONIT1Rate-RB"){
+record(longin,"$(P)$(R)INFOFAcqRate-RB"){
     field(DTYP,"asynUInt32Digital")
-    field(DESC,"get MONIT1 rate factor")
+    field(DESC,"get FAcq rate factor")
     field(SCAN,"I/O Intr")
     field(INP,"@asynMask($(PORT),$(ADDR),0xFFFFFFFF,$(TIMEOUT))INFO_MONIT1RATE")
 }

--- a/BPMApp/Db/BPMInfo_settings.req
+++ b/BPMApp/Db/BPMInfo_settings.req
@@ -4,4 +4,4 @@ $(P)$(R)INFOClkProp-Sel
 $(P)$(R)INFOTbTRate-SP
 $(P)$(R)INFOFOFBRate-SP
 $(P)$(R)INFOMONITRate-SP
-$(P)$(R)INFOMONIT1Rate-SP
+$(P)$(R)INFOFAcqRate-SP


### PR DESCRIPTION
Monit1 has been renamed to FAcq (fast acquisition rate) to avoid confusion with the Monit rate.