### PR TITLE
BPMApp: fix IntlkLmtMinSumCalc-RB.

### DIFF
--- a/BPMApp/Db/BPMIntlk.template
+++ b/BPMApp/Db/BPMIntlk.template
@@ -419,7 +419,7 @@ record(calc, "$(P)$(R)IntlkLmtMinSumCalc-RB"){
     field(SCAN, "Passive")
     field(INPA, "$(P)$(R)IntlkLmtMinSumHw-RB")
     field(INPB, "24")
-    field(CALC, "A<<B")
+    field(CALC, "A*(2^B)")
     field(FLNK, "$(P)$(R)IntlkLmtMinSum-RB")
 }
 


### PR DESCRIPTION
Using the bit shift directly on the value was operating with a 32-bit integer, and overflowing into a negative number. The multiplication makes it so the operations all happen with doubles.